### PR TITLE
Add Update Group action to Tokens

### DIFF
--- a/lib/src/broker/broker_profiles.dart
+++ b/lib/src/broker/broker_profiles.dart
@@ -178,6 +178,17 @@ Map<String, dynamic> brokerProfileMap = {
         r"$name": "Delete",
         r"$invokable": "config",
         r"$params": []
+      },
+      "update": {
+        r'$name': 'Update Group',
+        r'$invokable': 'config',
+        r'$params': [
+          {
+            'name': 'Group',
+            'type': 'string',
+            'description': 'default permission group'
+          }
+        ]
       }
     },
     "tokenGroup": {

--- a/lib/src/broker/tokens.dart
+++ b/lib/src/broker/tokens.dart
@@ -250,12 +250,19 @@ class TokenNode extends BrokerNode {
 
   void updateLinks() {
     if (links == null) return;
+
+    var updated = false;
     for (Object path in links) {
       if (path is! String) continue;
       Object nd = provider.getNode(path as String);
       if (nd is! RemoteLinkRootNode) continue;
       (nd as RemoteLinkRootNode).configs[r'$$group'] = group;
       (nd as RemoteLinkRootNode).updateList(r'$$group');
+      updated = true;
+    }
+
+    if (updated) {
+      DsTimer.timerOnceBefore(provider.saveConns, 300);
     }
   }
 }


### PR DESCRIPTION
Adds an action to TokenNode to "Update Group", enabling you to change the group associated with a token.
If group is empty, action is ignored.
Will attempt to update existing links if token is managed.