### PR TITLE
Fix for when using set value on Upstream URL

### DIFF
--- a/lib/src/broker/upstream.dart
+++ b/lib/src/broker/upstream.dart
@@ -240,6 +240,15 @@ class UpstreamUrlNode extends BrokerNode {
       var p = new Path(path).parentPath;
       UpstreamBrokerNode un = provider.getOrCreateNode(p, false);
 
+      try {
+        Uri.parse(value.toString());
+      } catch (e, s) {
+        var err = DSError.INVALID_VALUE;
+        err.msg = e.toString();
+        err.detail = s.toString();
+        return response..close(err);
+      }
+
       un.provider.removeLink(un.link, "@upstream@${un.name}", force: true);
       un.stop();
 


### PR DESCRIPTION
If you set the value the URL for an existing entry it would crash broker if URL was not able to be parsed.

This is virtually the same PR as the last, just in the setValue rather than createNode