### PR TITLE
Add option for strictTls to broker

### DIFF
--- a/lib/src/broker/broker_node_provider.dart
+++ b/lib/src/broker/broker_node_provider.dart
@@ -31,6 +31,7 @@ class BrokerNodeProvider extends NodeProviderImpl implements ServerLinkManager {
   BrokerNode upstreamDataNode;
   BrokerNode quarantineNode;
   BrokerNode tokens;
+  bool strictTls = false;
   Map<String, String> iconOwnerMappings = <String, String>{};
 
   BrokerConfigSetHandler setConfigHandler;
@@ -104,7 +105,8 @@ class BrokerNodeProvider extends NodeProviderImpl implements ServerLinkManager {
     this.defaultPermission,
     this.downstreamName: "conns",
     IStorageManager storage,
-    this.enabledDataNodes: true
+    this.enabledDataNodes: true,
+    this.strictTls: false
   }) {
     if (storage == null) {
       storage = new SimpleStorageManager("storage");

--- a/lib/src/broker/upstream.dart
+++ b/lib/src/broker/upstream.dart
@@ -483,9 +483,8 @@ class UpstreamBrokerNode extends BrokerNode {
       isResponder: true,
       overrideRequester: overrideRequester,
       overrideResponder: overrideResponder,
-      token: (
-        token != null && token.isNotEmpty
-      ) ? token : null
+      token: (token != null && token.isNotEmpty) ? token : null,
+      strictTls: p.strictTls
     );
 
     link.logName = "Upstream at /upstream/${name}";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,9 +4,7 @@ description: DSA Broker
 dependencies:
   uuid: 1.0.1
   dslink:
-    git:
-      url: https://github.com/IOT-DSA/sdk-dslink-dart.git
-      ref: feature/156805-StrictTLSCerts
+    git: https://github.com/IOT-DSA/sdk-dslink-dart.git
 environment:
   sdk: ^1.11.0
 executables:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,9 @@ description: DSA Broker
 dependencies:
   uuid: 1.0.1
   dslink:
-    git: https://github.com/IOT-DSA/sdk-dslink-dart.git
+    git:
+      url: https://github.com/IOT-DSA/sdk-dslink-dart.git
+      ref: feature/156805-StrictTLSCerts
 environment:
   sdk: ^1.11.0
 executables:


### PR DESCRIPTION
Allows broker CLI, or any inherited brokers to specify StrictTLS option to the LinkProvider.

Requires branch of the same name to be merged on SDK first.