### PR TITLE
Fix permission list validation for root node.

### DIFF
--- a/lib/src/broker/config_node.dart
+++ b/lib/src/broker/config_node.dart
@@ -43,7 +43,7 @@ class UpdateDefaultPermission extends BrokerStaticNode {
         }
       }
       if (!configFound) {
-        defaultPermission = [[':config','config']]..addAll(defaultPermission);
+        defaultPermission.insert(0, [':config', 'config']);
         updateData(defaultPermission);
         return;
       }


### PR DESCRIPTION
When root node is updated and does not contain `:config` then the
broker will inject `:config` into the parameters for next time but
did not inject into the permissions currently being injected.
Change takes advantage of Dart's pass-by-reference to inject the
config permissions into the list passed in, if it was not found.