### PR TITLE
get permission should create node for downstream

### DIFF
--- a/lib/src/broker/permission_actions.dart
+++ b/lib/src/broker/permission_actions.dart
@@ -27,7 +27,7 @@ class GetPermissionAction extends BrokerStaticNode {
       int permission = provider.permissions.getPermission(path, responder);
       String output;
       if (permission == Permission.CONFIG) {
-        LocalNode node = provider.getNode(path);
+        LocalNode node = provider.getOrCreateNode(path, false);
         if (node is BrokerNode) {
           List permission = node.serializePermission();
           if (permission != null) {


### PR DESCRIPTION
downstream node are create on demand, but the permission for downstream is not stored in node.
so node==null doesn't mean permission is not there