### PR TITLE
update qos on change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* v1.1.4 - Resolve issue with QOS values not propagating downgrades.
 * v1.1.1+1 - Additional logging during failed websocket upgrades
 * v1.1.1 - Additional logging during failed handshakes.
 * v1.1.0 - Start of changelog. Too many previous changes to list.

--- a/lib/src/broker/remote_node.dart
+++ b/lib/src/broker/remote_node.dart
@@ -202,13 +202,9 @@ class RemoteLinkNode extends RemoteNode implements LocalNode {
   RespSubscribeListener subscribe(callback(ValueUpdate), [int qos = 0]) {
     callbacks[callback] = qos;
     var rslt = new RespSubscribeListener(this, callback);
-    if (valueReady) {
-      callback(_lastValueUpdate);
-    }
-    if ( qos > lastQos) {
-      lastQos = qos;
-      _linkManager.requester.subscribe(remotePath, updateValue, qos);
-    }
+
+    if (valueReady) callback(_lastValueUpdate);
+    if (qos != lastQos) updateSubscriptionQos();
 
     return rslt;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dsbroker
-version: 1.1.3
+version: 1.1.4
 description: DSA Broker which manages connections of DSLinks
 authors:
 - Rick Zhou <rinick@gmail.com>


### PR DESCRIPTION
Resolves an issue where QOS downgrades were not being propagated down to the DSlink (only upgrade requests)